### PR TITLE
Acknowledge MIT-licensed components

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Yarn Weaver contains the following third-party open source software, the use of which is hereby acknowledged:
+
+UnityStandaloneFileBrowser, copyright (c) 2017 Gökhan Gökçe (https://github.com/gkngkc/UnityStandaloneFileBrowser).
+Yarn Spinner, copyright (c) 2015-2017 Secret Lab Pty. Ltd. and Yarn Spinner contributors. (https://github.com/thesecretlab/YarnSpinner)


### PR DESCRIPTION
The MIT license requires that acknowledgement and a copy of the MIT license be included in copies of the software. Yarn Weaver already includes the MIT license, but it didn't include the acknowledgement. This change adds them to the LICENSE file.